### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/danLib/keywords.txt
+++ b/danLib/keywords.txt
@@ -1,6 +1,6 @@
 /* 
-	KEYWORD1 �����r
-	KEYWORD2 �зǾ�r
+	KEYWORD1 ²ÊÅé¾ï¦r
+	KEYWORD2 ¼Ð·Ç¾ï¦r
 */
 
 
@@ -19,8 +19,8 @@
 
 
 StringManager	KEYWORD1
-PCSerialManager KEYWORD1
-BlueToothSerialManager KEYWORD1
+PCSerialManager	KEYWORD1
+BlueToothSerialManager	KEYWORD1
 
 
 
@@ -34,10 +34,10 @@ BlueToothSerialManager KEYWORD1
 
 Split	KEYWORD2
 Initial	KEYWORD2
-initial KEYWORD2
+initial	KEYWORD2
 Run	KEYWORD2
 Receive_LineString	KEYWORD2
-Check_And_Process_LineString KEYWORD2
+Check_And_Process_LineString	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords